### PR TITLE
Add Unit Tests for connection manager

### DIFF
--- a/RapidMQ/RapidMQ/Models/ConnectionManagerConfig.cs
+++ b/RapidMQ/RapidMQ/Models/ConnectionManagerConfig.cs
@@ -28,8 +28,11 @@ public class ConnectionManagerConfig
     /// Custom client delegate invoked when re-trying to connect to the broker.
     /// </summary>
     public Func<Exception, int, TimeSpan, Task>? OnReconnectRetryEventHandler { get; init; }
-    
-    public Action? OnConnectionRecovery { get; init; }
+
+    /// <summary>
+    /// Represents a delegate that client can provide to be invoked when the connection is recovered.
+    /// </summary>
+    public Func<Task>? OnConnectionRecovery { get; init; }
 
     public ConnectionManagerConfig(int maxConnectionRetries, TimeSpan delayBetweenRetries,
         bool exponentialBackoffRetry)
@@ -60,11 +63,11 @@ public class ConnectionManagerConfig
         OnConnectionShutdownEventHandler = onConnectionShutdownEventHandler;
         OnReconnectRetryEventHandler = onReconnectRetryEventHandler;
     }
-    
+
     public ConnectionManagerConfig(int maxConnectionRetries, TimeSpan delayBetweenRetries,
         bool exponentialBackoffRetry,
         Func<ShutdownEventArgs, Task>? onConnectionShutdownEventHandler,
-        Func<Exception, int, TimeSpan, Task>? onReconnectRetryEventHandler, Action? onConnectionRecovery)
+        Func<Exception, int, TimeSpan, Task>? onReconnectRetryEventHandler, Func<Task>? onConnectionRecovery)
     {
         MaxConnectionRetries = maxConnectionRetries;
         DelayBetweenRetries = delayBetweenRetries;

--- a/RapidMQ/RapidMQ/RapidMQ.csproj
+++ b/RapidMQ/RapidMQ/RapidMQ.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-preview.6.23329.7" />
+      <PackageReference Include="Moq" Version="4.20.69" />
       <PackageReference Include="Polly" Version="8.0.0-alpha.4" />
       <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
     </ItemGroup>

--- a/RapidMQ/RapidMq.Unit.Tests/ConnectionManager.Spec/ConnectionManagerTests.cs
+++ b/RapidMQ/RapidMq.Unit.Tests/ConnectionManager.Spec/ConnectionManagerTests.cs
@@ -1,0 +1,6 @@
+﻿namespace RapidMq.Unit.Tests.ConnectionManager.Spec;
+
+public class ConnectionManagerTests
+{
+    
+}

--- a/RapidMQ/RapidMq.Unit.Tests/ConnectionManager.Spec/ConnectionManagerTests.cs
+++ b/RapidMQ/RapidMq.Unit.Tests/ConnectionManager.Spec/ConnectionManagerTests.cs
@@ -1,6 +1,51 @@
-﻿namespace RapidMq.Unit.Tests.ConnectionManager.Spec;
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Exceptions;
+using RapidMQ.Models;
+using Xunit;
+
+namespace RapidMq.Unit.Tests.ConnectionManager.Spec;
 
 public class ConnectionManagerTests
 {
-    
+    private readonly Mock<ILogger<RapidMQ.ConnectionManager>> _mockLogger;
+    private readonly TestableConnectionManager _testableConnectionManager;
+    private readonly Mock<IConnection> _mockConnection;
+
+    private const string RabbitMqUri = "amqp://localhost";
+
+    public ConnectionManagerTests()
+    {
+        _mockLogger = new Mock<ILogger<RapidMQ.ConnectionManager>>();
+        _mockConnection = new Mock<IConnection>();
+        _testableConnectionManager = new TestableConnectionManager(_mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task ConnectionManager_Should_Return_ConnectionInstance()
+    {
+        var config = new ConnectionManagerConfig(3, TimeSpan.FromMilliseconds(100), false);
+
+        var mockConnection = new Mock<IConnection>();
+        _testableConnectionManager.CreateConnectionInstanceMock = uri => mockConnection.Object;
+
+        var connection = await _testableConnectionManager.ConnectAsync(new Uri(RabbitMqUri), config);
+
+        Assert.NotNull(connection);
+        Assert.Same(mockConnection.Object, connection);
+    }
+
+
+    [Fact]
+    public async Task ConnectionManager_Should_Retry_Until_Successful()
+    {
+        var config = new ConnectionManagerConfig(3, TimeSpan.FromMilliseconds(100), false);
+
+        _testableConnectionManager.FailuresToSimulate = 2;
+
+        var connection = await _testableConnectionManager.ConnectAsync(new Uri(RabbitMqUri), config);
+
+        Assert.NotNull(connection);
+    }
 }

--- a/RapidMQ/RapidMq.Unit.Tests/ConnectionManager.Spec/TestableConnectionManager.cs
+++ b/RapidMQ/RapidMq.Unit.Tests/ConnectionManager.Spec/TestableConnectionManager.cs
@@ -1,0 +1,6 @@
+﻿namespace RapidMq.Unit.Tests.ConnectionManager.Spec;
+
+public class TestableConnectionManager
+{
+    
+}

--- a/RapidMQ/RapidMq.Unit.Tests/ConnectionManager.Spec/TestableConnectionManager.cs
+++ b/RapidMQ/RapidMq.Unit.Tests/ConnectionManager.Spec/TestableConnectionManager.cs
@@ -1,6 +1,23 @@
-﻿namespace RapidMq.Unit.Tests.ConnectionManager.Spec;
+﻿using Microsoft.Extensions.Logging;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Exceptions;
 
-public class TestableConnectionManager
+public class TestableConnectionManager : RapidMQ.ConnectionManager
 {
-    
+    public int FailuresToSimulate { get; set; } = 0;
+    private int _currentFailures = 0;
+    public Func<Uri, IConnection> CreateConnectionInstanceMock { get; set; }
+
+    public TestableConnectionManager(ILogger<RapidMQ.ConnectionManager> logger)
+        : base(logger)
+    {
+    }
+
+    protected override IConnection CreateConnectionInstance(Uri uri)
+    {
+        if (_currentFailures >= FailuresToSimulate)
+            return CreateConnectionInstanceMock?.Invoke(uri) ?? base.CreateConnectionInstance(uri);
+        _currentFailures++;
+        throw new BrokerUnreachableException(new Exception("Simulated connection failure."));
+    }
 }

--- a/RapidMQ/RapidMq.Unit.Tests/GlobalUsings.cs
+++ b/RapidMQ/RapidMq.Unit.Tests/GlobalUsings.cs
@@ -1,1 +1,0 @@
-global using Xunit;

--- a/RapidMQ/RapidMq.Unit.Tests/PolicyProvider.Spec/PolicyProviderTests.cs
+++ b/RapidMQ/RapidMq.Unit.Tests/PolicyProvider.Spec/PolicyProviderTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics;
 using RapidMQ.Internals;
+using Xunit;
 
 namespace RapidMq.Unit.Tests.PolicyProvider.Spec;
 

--- a/RapidMQ/RapidMq.Unit.Tests/RapidMq.Unit.Tests.csproj
+++ b/RapidMQ/RapidMq.Unit.Tests/RapidMq.Unit.Tests.csproj
@@ -27,4 +27,6 @@
       <ProjectReference Include="..\RapidMQ\RapidMQ.csproj" />
     </ItemGroup>
 
+
+
 </Project>


### PR DESCRIPTION
Wrote few tests for connection manager component and fixed some the execution of client's handler when being invoked on the connection events (drops, retries and connection recovers).
Now instead of just executing it in a new thread, it also catches if there is any failure during it's invocation.